### PR TITLE
fuzz test for balances/total supply invariant

### DIFF
--- a/src/staking/Momentum.sol
+++ b/src/staking/Momentum.sol
@@ -1,12 +1,13 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IERC20}            from "forge-std/interfaces/IERC20.sol";
-import {ERC20}             from "solmate/tokens/ERC20.sol";
+import {IERC20} from "forge-std/interfaces/IERC20.sol";
+import {ERC20} from "solmate/tokens/ERC20.sol";
 import {IERC721Enumerable} from "forge-std/interfaces/IERC721.sol";
 
-import {IVaultManager}     from "../interfaces/IVaultManager.sol";
-import {IVault}            from "../interfaces/IVault.sol";
+import {IVaultManager} from "../interfaces/IVaultManager.sol";
+import {IVault} from "../interfaces/IVault.sol";
+import {FixedPointMathLib} from "solmate/utils/FixedPointMathLib.sol";
 
 struct NoteMomentumData {
     // uint40 supports 34,000 years before overflow
@@ -21,53 +22,51 @@ contract Momentum is IERC20 {
     error TransferNotAllowed();
     error NotVaultManager();
 
-    IVaultManager     public immutable VAULT_MANAGER;
+    IVaultManager public immutable VAULT_MANAGER;
     IERC721Enumerable public immutable DNFT;
-    IVault            public immutable KEROSENE_VAULT;
-    ERC20             public immutable KEROSENE;
+    IVault public immutable KEROSENE_VAULT;
+    ERC20 public immutable KEROSENE;
 
-    string public constant name     = "Kerosene Momentum";
-    string public constant symbol   = "kMOM";
-    uint8  public constant decimals = 18;
+    string public constant name = "Kerosene Momentum";
+    string public constant symbol = "kMOM";
+    uint8 public constant decimals = 18;
 
-    uint40  globalLastUpdate;
-    uint192 globalLastKeroseneInVault;
+    uint40 globalLastUpdate;
+    uint192 globalLastMomentum;
 
     mapping(uint256 => NoteMomentumData) public noteData;
 
     constructor(address vaultManager, address keroseneVault, address dnft) {
-      VAULT_MANAGER  = IVaultManager(vaultManager);
-      DNFT           = IERC721Enumerable(dnft);
-      KEROSENE_VAULT = IVault(keroseneVault);
-      KEROSENE       = ERC20(KEROSENE_VAULT.asset());
+        VAULT_MANAGER = IVaultManager(vaultManager);
+        DNFT = IERC721Enumerable(dnft);
+        KEROSENE_VAULT = IVault(keroseneVault);
+        KEROSENE = ERC20(KEROSENE_VAULT.asset());
 
-      // initialize momentum values
-      globalLastUpdate          = uint40(block.timestamp);
-      globalLastKeroseneInVault = uint192(KEROSENE.balanceOf(keroseneVault));
-      uint256 dnftSupply        = DNFT.totalSupply();
+        globalLastUpdate = uint40(block.timestamp);
+        uint256 dnftSupply = DNFT.totalSupply();
 
-      for (uint256 i = 0; i < dnftSupply; ++i) {
-          uint256 depositedKero = KEROSENE_VAULT.id2asset(i);
-          if (depositedKero == 0) { continue; }
-          noteData[i] = NoteMomentumData({
-              lastAction:        uint40(block.timestamp),
-              keroseneDeposited: uint96(depositedKero),
-              lastMomentum:      uint120(0)
-          });
-      }
+        for (uint256 i = 0; i < dnftSupply; ++i) {
+            uint256 depositedKero = KEROSENE_VAULT.id2asset(i);
+            if (depositedKero == 0) {
+                continue;
+            }
+            noteData[i] = NoteMomentumData({
+                lastAction: uint40(block.timestamp),
+                keroseneDeposited: uint96(depositedKero),
+                lastMomentum: uint120(0)
+            });
+        }
     }
 
     /// @notice Returns the amount of tokens in existence.
     function totalSupply() external view returns (uint256) {
-        // TODO - I don't think this logic is right. 
+        // TODO - I don't think this logic is right.
         // should be last global MOMENTUM + (time elapsed * kerosene in vault)?
         // invariant, total supply should equal sum of all note amounts but looping through
         // all notes is expensive from a gas perspective especially as the number of notes grows
         // unbounded over time.
         uint256 timeElapsed = block.timestamp - globalLastUpdate;
-        uint256 keroseneInVault = KEROSENE.balanceOf(address(KEROSENE_VAULT));
-        uint256 momentumAccrued = timeElapsed * keroseneInVault;
-        return globalLastKeroseneInVault + momentumAccrued;
+        return  globalLastMomentum + uint192(timeElapsed * 1e18);
     }
 
     /// @notice Returns the amount of tokens owned by `account`.
@@ -144,8 +143,8 @@ contract Momentum is IERC20 {
             lastMomentum: uint120(newMomentum)
         });
 
+        globalLastMomentum += uint192((globalLastUpdate - block.timestamp) * 1e18);
         globalLastUpdate = uint40(block.timestamp);
-        globalLastKeroseneInVault = uint192(totalKeroseneInVault);
 
         emit Transfer(
             address(0),
@@ -183,16 +182,15 @@ contract Momentum is IERC20 {
             lastMomentum: uint120(updatedMomentum)
         });
 
+        globalLastMomentum += uint192((globalLastUpdate - block.timestamp) * 1e18);
         globalLastUpdate = uint40(block.timestamp);
-        globalLastKeroseneInVault = uint192(totalKeroseneInVault);
     }
 
     function _computeMomentum(
         uint256 totalKeroseneInVault,
         NoteMomentumData memory lastUpdate
     ) internal view returns (uint256) {
-        uint256 userShare = (uint256(lastUpdate.keroseneDeposited) * 1e18) /
-            totalKeroseneInVault;
+        uint256 userShare = FixedPointMathLib.divWadUp(lastUpdate.keroseneDeposited, totalKeroseneInVault);
         uint256 timePassed = block.timestamp - lastUpdate.lastAction;
         uint256 momentumAccrued = timePassed * userShare;
 

--- a/test/fuzz/Momentum.fuzz.t.sol
+++ b/test/fuzz/Momentum.fuzz.t.sol
@@ -1,0 +1,100 @@
+import {Test} from "forge-std/Test.sol";
+import {IVaultManager} from "../../src/interfaces/IVaultManager.sol";
+import {Momentum} from "../../src/staking/Momentum.sol";
+import {Kerosine} from "../../src/staking/Kerosine.sol";
+import {DNft} from "../../src/core/DNft.sol";
+import {KeroseneVault} from "../../src/core/VaultKerosene.sol";
+import {Dyad} from "../../src/core/Dyad.sol";
+import {IAggregatorV3} from "../../src/interfaces/IAggregatorV3.sol";
+import {KerosineManager} from "../../src/core/KerosineManager.sol";
+import {Licenser} from "../../src/core/Licenser.sol";
+import {KerosineDenominator} from "../../src/staking/KerosineDenominator.sol";
+
+contract MomentumFuzzTest is Test {
+    address VAULT_MANAGER = address(0x5678);
+
+    Momentum momentum;
+    Kerosine kerosine;
+    DNft dnft;
+    Dyad dyad;
+    KeroseneVault keroseneVault;
+
+    address USER_1 = address(0x1111);
+    address USER_2 = address(0x2222);
+    address USER_3 = address(0x3333);
+
+    function setUp() external {
+        dyad = new Dyad(Licenser(address(0x0)));
+        dnft = new DNft();
+        kerosine = new Kerosine();
+        keroseneVault = new KeroseneVault(
+            IVaultManager(VAULT_MANAGER),
+            kerosine,
+            dyad,
+            KerosineManager(address(0x0)),
+            IAggregatorV3(address(0x0)),
+            KerosineDenominator(address(0x0))
+        );
+        momentum = new Momentum(
+            VAULT_MANAGER,
+            address(keroseneVault),
+            address(dnft)
+        );
+
+        dnft.mintInsiderNft(USER_1);
+        dnft.mintInsiderNft(USER_2);
+        dnft.mintInsiderNft(USER_3);
+    }
+
+    function testFuzz_totalSupplyEqualsAllBalances(
+        uint256 deposit1,
+        uint256 deposit2,
+        uint256 deposit3
+    ) external {
+        vm.assume(deposit1 > 0);
+        vm.assume(deposit2 > 0);
+        vm.assume(deposit3 > 0);
+        vm.assume(deposit1 < kerosine.totalSupply());
+        vm.assume(deposit2 < kerosine.totalSupply());
+        vm.assume(deposit3 < kerosine.totalSupply());
+        vm.assume(deposit1 + deposit2 + deposit3 <= kerosine.totalSupply());
+
+        kerosine.transfer(address(keroseneVault), deposit1);
+        vm.startPrank(VAULT_MANAGER);
+        keroseneVault.deposit(0, deposit1);
+        momentum.afterKeroseneDeposited(0);
+        vm.stopPrank();
+
+        kerosine.transfer(address(keroseneVault), deposit2);
+        vm.startPrank(VAULT_MANAGER);
+        keroseneVault.deposit(1, deposit2);
+        momentum.afterKeroseneDeposited(1);
+        vm.stopPrank();
+
+        kerosine.transfer(address(keroseneVault), deposit3);
+        vm.startPrank(VAULT_MANAGER);
+        keroseneVault.deposit(2, deposit3);
+        momentum.afterKeroseneDeposited(2);
+        vm.stopPrank();
+
+        _checkInvariantSupplyBalances();
+
+        vm.warp(block.timestamp + 1 minutes);
+        _checkInvariantSupplyBalances();
+
+        vm.warp(block.timestamp + 1 hours);
+        _checkInvariantSupplyBalances();
+
+        vm.warp(block.timestamp + 1 days);
+        _checkInvariantSupplyBalances();
+    }
+
+    function _checkInvariantSupplyBalances() internal view {
+        uint256 totalSupply = momentum.totalSupply();
+        uint256 balance1 = momentum.balanceOf(USER_1);
+        uint256 balance2 = momentum.balanceOf(USER_2);
+        uint256 balance3 = momentum.balanceOf(USER_3);
+
+        vm.assertEq(totalSupply, balance1 + balance2 + balance3);
+    }
+}


### PR DESCRIPTION
fuzz test for sum of `balanceOf` + `totalSupply()` invariant

Currently not working due to rounding issues. Fixes totalSupply calculation to be

```
totalSupply = time elapsed since initialization
```

Total emission is 1 MOMENTUM per second forever, distributed proportionally across all notes w/kerosene